### PR TITLE
Integrate flutter_mock_server for local development and testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,10 +1,29 @@
 {
     "configurations": [
         {
-        "name": "Flutter Run",
-        "type": "dart",
-        "request": "launch",
-        "program": "lib/main.dart"
-    }
+            "name": "Flutter Run",
+            "type": "dart",
+            "request": "launch",
+            "program": "lib/main.dart"
+        },
+        {
+            "name": "Flutter (Chrome)",
+            "type": "dart",
+            "request": "launch",
+            "program": "lib/main.dart",
+            "deviceId": "chrome"
+        },
+        {
+            "name": "Flutter (Chrome) + Mock Server",
+            "type": "dart",
+            "request": "launch",
+            "program": "lib/main.dart",
+            "deviceId": "chrome",
+            "args": [
+                "--web-browser-flag",
+                "--disable-web-security"
+            ],
+            "preLaunchTask": "Start Mock Server"
+        }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start Mock Server",
+            "type": "shell",
+            "command": "dart run flutter_mock_server start",
+            "isBackground": true,
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": "^$"
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^Mock server",
+                    "endsPattern": "^Mock server listening"
+                }
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated",
+                "label": "Mock Server"
+            }
+        }
+    ]
+}

--- a/mock.yaml
+++ b/mock.yaml
@@ -1,0 +1,171 @@
+# organize_it – development mock server
+# ──────────────────────────────────────
+# Start: dart run flutter_mock_server start
+# The app's DioService defaults to http://localhost:8080 — no extra config needed.
+#
+# Feature overview used here:
+#   models      – schema-driven fake data (uuid, word, sentence, bool, enum, timestamp, array)
+#   stores      – deterministic in-memory collections seeded from models
+#   seed        – fixed seed so generated data is identical on every reload
+#   CRUD routes – list / get / create / update / delete backed by a store
+#   filtering   – ?priority=HIGH  ?isCompleted=true  (any non-reserved query key)
+#   sorting     – ?sort=title&order=asc|desc
+#   pagination  – ?limit=5&page=2
+#   static body – inline body with template bindings ({{uuid}}, {{request.body.X}})
+#   headers     – custom response headers
+#   delay_ms    – artificial latency for simulating slow networks
+#   error       – probabilistic error injection (raise `rate` to 0.0–1.0)
+
+seed: 42
+
+models:
+  Task:
+    id: uuid
+    title: word
+    description: sentence
+    isCompleted: bool
+    priority:
+      enum: [HIGH, MEDIUM, LOW]
+    ownerId: uuid
+    createdAt: timestamp
+    updatedAt: timestamp
+
+  TaskGroup:
+    id: uuid
+    name: word
+    description: sentence
+    ownerId: uuid
+    isActive: bool
+    tasksList:
+      type: array
+      items: uuid
+      count: 3
+    createdAt: timestamp
+    updatedAt: timestamp
+
+stores:
+  tasks:
+    model: Task
+    count: 12
+
+  task_groups:
+    model: TaskGroup
+    count: 5
+
+routes:
+  # ── Tasks ─────────────────────────────────────────────────────────────────
+  # Supports arbitrary field filters, e.g.:
+  #   ?priority=HIGH
+  #   ?isCompleted=true
+  #   ?sort=title&order=asc&limit=5&page=1
+  - path: /tasks
+    method: GET
+    action: list
+    store: tasks
+
+  - path: /tasks/:id
+    method: GET
+    action: get
+    store: tasks
+
+  - path: /tasks
+    method: POST
+    action: create
+    store: tasks
+
+  - path: /tasks/:id
+    method: PUT
+    action: update
+    store: tasks
+
+  - path: /tasks/:id
+    method: DELETE
+    action: delete
+    store: tasks
+
+  # ── Task Groups ───────────────────────────────────────────────────────────
+  - path: /task-groups
+    method: GET
+    action: list
+    store: task_groups
+
+  - path: /task-groups/:id
+    method: GET
+    action: get
+    store: task_groups
+
+  - path: /task-groups
+    method: POST
+    action: create
+    store: task_groups
+
+  - path: /task-groups/:id
+    method: PUT
+    action: update
+    store: task_groups
+
+  - path: /task-groups/:id
+    method: DELETE
+    action: delete
+    store: task_groups
+
+  # ── Auth ──────────────────────────────────────────────────────────────────
+  # Template bindings populate token/userId from generated UUIDs and email
+  # from the incoming request body.
+  # Raise `error.rate` to 0.0–1.0 to simulate 401 failures during development.
+  - path: /session
+    method: POST
+    response:
+      status: 201
+      headers:
+        Access-Control-Allow-Origin: "*"
+        Access-Control-Allow-Methods: "GET, POST, PUT, DELETE"
+        Access-Control-Allow-Headers: "Content-Type, Authorization"
+      body:
+        token: "{{uuid}}"
+        userId: "{{uuid}}"
+        message: Signed in
+        email: "{{request.body.email}}"
+      error:
+        status: 401
+        rate: 0.0
+        body:
+          message: Unauthorized
+
+  # ── Health ────────────────────────────────────────────────────────────────
+  - path: /health
+    method: GET
+    response:
+      status: 200
+      headers:
+        Access-Control-Allow-Origin: "*"
+        x-server: flutter-mock-server
+      body:
+        status: ok
+        version: "1.0.0"
+        environment: development
+
+  # ── Test / development utilities ──────────────────────────────────────────
+  - path: /test/always-error
+    method: GET
+    response:
+      status: 200
+      headers:
+        Access-Control-Allow-Origin: "*"
+      body:
+        ok: true
+      error:
+        status: 503
+        rate: 1.0
+        body:
+          message: Simulated server error
+
+  - path: /test/delayed
+    method: GET
+    response:
+      status: 200
+      headers:
+        Access-Control-Allow-Origin: "*"
+      body:
+        ok: true
+      delay_ms: 50

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,6 +254,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_mock_server:
+    dependency: "direct dev"
+    description:
+      name: flutter_mock_server
+      sha256: "6273bcee5e952973c554406e40434d351fdc9d18dc5111fd412c57aef9c28f34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -680,6 +688,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
+  flutter_mock_server: ^1.0.0
 
   # Lints
   flutter_lints: ^6.0.0

--- a/test/helpers/mock_server_helper.dart
+++ b/test/helpers/mock_server_helper.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+
+import 'package:flutter_mock_server/flutter_mock_server.dart';
+
+/// Holds a running [FlutterMockServer] instance together with its ephemeral
+/// port and temporary directory so callers can tear down cleanly.
+class MockServerHandle {
+  MockServerHandle._({
+    required this.server,
+    required this.port,
+    required Directory tempDir,
+  }) : _tempDir = tempDir;
+
+  final FlutterMockServer server;
+
+  /// The ephemeral port the server is listening on.
+  final int port;
+
+  final Directory _tempDir;
+
+  /// Convenience base URL ready for use with [DioService].
+  String get baseUrl => 'http://127.0.0.1:$port';
+
+  /// Stops the server and removes the temporary YAML config file.
+  Future<void> stop() async {
+    await server.stop();
+    if (await _tempDir.exists()) {
+      await _tempDir.delete(recursive: true);
+    }
+  }
+}
+
+/// Starts a [FlutterMockServer] pre-configured with the organize_it task API.
+///
+/// Uses an ephemeral OS-assigned port so multiple test groups can run in
+/// parallel without port collisions.  The YAML content is embedded here so
+/// the tests are hermetic — no filesystem path assumptions are needed.
+Future<MockServerHandle> startTasksMockServer() async {
+  final port = await _freePort();
+  final tempDir = await Directory.systemTemp.createTemp('organize_it_mock_');
+  final configFile = File('${tempDir.path}/mock.yaml');
+  await configFile.writeAsString(_mockYaml());
+
+  final server = FlutterMockServer(
+    configPath: configFile.path,
+    host: '127.0.0.1',
+    port: port,
+  );
+  await server.start();
+
+  return MockServerHandle._(server: server, port: port, tempDir: tempDir);
+}
+
+/// Binds to port 0 to let the OS choose a free port, then releases the socket.
+Future<int> _freePort() async {
+  final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = socket.port;
+  await socket.close();
+  return port;
+}
+
+/// YAML configuration that mirrors [mock.yaml] at the repo root.
+///
+/// Features exercised:
+///   - [seed]        deterministic generated data across reloads
+///   - [models]      uuid, word, sentence, bool, enum, timestamp, array
+///   - [stores]      in-memory seeded collections
+///   - CRUD actions  list / get / create / update / delete
+///   - [headers]     custom response headers
+///   - [delay_ms]    artificial latency
+///   - [error]       probabilistic error injection
+///   - template      {{uuid}}, {{request.body.X}}
+String _mockYaml() => r'''
+seed: 42
+
+models:
+  Task:
+    id: uuid
+    title: word
+    description: sentence
+    isCompleted: bool
+    priority:
+      enum: [HIGH, MEDIUM, LOW]
+    ownerId: uuid
+    createdAt: timestamp
+    updatedAt: timestamp
+
+  TaskGroup:
+    id: uuid
+    name: word
+    description: sentence
+    ownerId: uuid
+    isActive: bool
+    tasksList:
+      type: array
+      items: uuid
+      count: 3
+    createdAt: timestamp
+    updatedAt: timestamp
+
+stores:
+  tasks:
+    model: Task
+    count: 12
+
+  task_groups:
+    model: TaskGroup
+    count: 5
+
+routes:
+  - path: /tasks
+    method: GET
+    action: list
+    store: tasks
+
+  - path: /tasks/:id
+    method: GET
+    action: get
+    store: tasks
+
+  - path: /tasks
+    method: POST
+    action: create
+    store: tasks
+
+  - path: /tasks/:id
+    method: PUT
+    action: update
+    store: tasks
+
+  - path: /tasks/:id
+    method: DELETE
+    action: delete
+    store: tasks
+
+  - path: /task-groups
+    method: GET
+    action: list
+    store: task_groups
+
+  - path: /task-groups/:id
+    method: GET
+    action: get
+    store: task_groups
+
+  - path: /task-groups
+    method: POST
+    action: create
+    store: task_groups
+
+  - path: /task-groups/:id
+    method: PUT
+    action: update
+    store: task_groups
+
+  - path: /task-groups/:id
+    method: DELETE
+    action: delete
+    store: task_groups
+
+  - path: /session
+    method: POST
+    response:
+      status: 201
+      body:
+        token: "{{uuid}}"
+        userId: "{{uuid}}"
+        message: Signed in
+        email: "{{request.body.email}}"
+      error:
+        status: 401
+        rate: 0.0
+        body:
+          message: Unauthorized
+
+  - path: /health
+    method: GET
+    response:
+      status: 200
+      headers:
+        x-server: flutter-mock-server
+      body:
+        status: ok
+        version: "1.0.0"
+        environment: development
+
+  - path: /test/always-error
+    method: GET
+    response:
+      status: 200
+      body:
+        ok: true
+      error:
+        status: 503
+        rate: 1.0
+        body:
+          message: Simulated server error
+
+  - path: /test/delayed
+    method: GET
+    response:
+      status: 200
+      body:
+        ok: true
+      delay_ms: 50
+''';

--- a/test/integration/dio_service_integration_test.dart
+++ b/test/integration/dio_service_integration_test.dart
@@ -1,0 +1,379 @@
+// Integration tests for DioService against a live FlutterMockServer.
+//
+// Each group gets its own server instance so tests are fully isolated.
+// These tests exercise every mock-server feature:
+//   - CRUD store actions (list, get, create, update, delete)
+//   - Query filtering, sorting, and pagination
+//   - Static response with template bindings ({{uuid}}, {{request.body.X}})
+//   - Custom response headers
+//   - Probabilistic error injection (rate: 1.0 → always fires)
+//   - Artificial response delay (delay_ms)
+import 'package:flutter_test/flutter_test.dart';
+import 'package:organize_it/services/dio_service.dart';
+
+import '../helpers/mock_server_helper.dart';
+
+void main() {
+  group('DioService – /health', () {
+    late MockServerHandle handle;
+    late DioService dio;
+
+    setUp(() async {
+      handle = await startTasksMockServer();
+      dio = DioService(baseUrl: handle.baseUrl);
+    });
+    tearDown(() => handle.stop());
+
+    test('returns 200 with body and custom header', () async {
+      final r = await dio.getRequest('/health');
+
+      expect(r.statusCode, 200);
+      expect(r.data['status'], 'ok');
+      expect(r.data['version'], '1.0.0');
+      expect(r.data['environment'], 'development');
+      // Custom header set via the `headers` field in mock.yaml.
+      expect(r.headers.value('x-server'), 'flutter-mock-server');
+    });
+  });
+
+  group('DioService – /session (static + template bindings)', () {
+    late MockServerHandle handle;
+    late DioService dio;
+
+    setUp(() async {
+      handle = await startTasksMockServer();
+      dio = DioService(baseUrl: handle.baseUrl);
+    });
+    tearDown(() => handle.stop());
+
+    test('returns 201 with token, userId, and echoed email', () async {
+      final r = await dio.postRequest(
+        '/session',
+        data: {'email': 'dev@example.com'},
+      );
+
+      expect(r.statusCode, 201);
+      expect(r.data['token'], isA<String>());
+      expect((r.data['token'] as String).isNotEmpty, isTrue);
+      expect(r.data['userId'], isA<String>());
+      // Template binding: {{request.body.email}} echoes back the posted email.
+      expect(r.data['email'], 'dev@example.com');
+      expect(r.data['message'], 'Signed in');
+    });
+  });
+
+  group('DioService – GET /tasks (list, filter, sort, paginate)', () {
+    late MockServerHandle handle;
+    late DioService dio;
+
+    setUp(() async {
+      handle = await startTasksMockServer();
+      dio = DioService(baseUrl: handle.baseUrl);
+    });
+    tearDown(() => handle.stop());
+
+    test('returns all 12 seeded tasks', () async {
+      final r = await dio.getRequest('/tasks');
+
+      expect(r.statusCode, 200);
+      expect((r.data as List).length, 12);
+    });
+
+    test('filters by priority (exact-match query param)', () async {
+      final r = await dio.getRequest(
+        '/tasks',
+        queryParameters: {'priority': 'HIGH'},
+      );
+      final tasks = r.data as List;
+
+      expect(
+        tasks.every((t) => (t as Map<String, dynamic>)['priority'] == 'HIGH'),
+        isTrue,
+      );
+    });
+
+    test('filters by isCompleted', () async {
+      final r = await dio.getRequest(
+        '/tasks',
+        queryParameters: {'isCompleted': 'true'},
+      );
+      final tasks = r.data as List;
+
+      expect(
+        tasks.every((t) => (t as Map<String, dynamic>)['isCompleted'] == true),
+        isTrue,
+      );
+    });
+
+    test('sorts by title ascending', () async {
+      final r = await dio.getRequest(
+        '/tasks',
+        queryParameters: {'sort': 'title', 'order': 'asc'},
+      );
+      final titles = (r.data as List)
+          .map((t) => (t as Map<String, dynamic>)['title'] as String)
+          .toList();
+      final sorted = List<String>.from(titles)..sort();
+
+      expect(titles, sorted);
+    });
+
+    test('sorts by title descending', () async {
+      final r = await dio.getRequest(
+        '/tasks',
+        queryParameters: {'sort': 'title', 'order': 'desc'},
+      );
+      final titles = (r.data as List)
+          .map((t) => (t as Map<String, dynamic>)['title'] as String)
+          .toList();
+      final reversed = List<String>.from(titles)
+        ..sort((a, b) => b.compareTo(a));
+
+      expect(titles, reversed);
+    });
+
+    test('paginates: page 1 and page 2 have distinct records', () async {
+      final page1 = await dio.getRequest(
+        '/tasks',
+        queryParameters: {'limit': '5', 'page': '1'},
+      );
+      final page2 = await dio.getRequest(
+        '/tasks',
+        queryParameters: {'limit': '5', 'page': '2'},
+      );
+
+      expect((page1.data as List).length, 5);
+      expect((page2.data as List).length, 5);
+
+      final ids1 = (page1.data as List).map((t) => t['id'] as String).toSet();
+      final ids2 = (page2.data as List).map((t) => t['id'] as String).toSet();
+      expect(ids1.intersection(ids2), isEmpty);
+    });
+
+    test('page beyond range returns empty list', () async {
+      final r = await dio.getRequest(
+        '/tasks',
+        queryParameters: {'limit': '5', 'page': '99'},
+      );
+
+      expect(r.data, isEmpty);
+    });
+  });
+
+  group('DioService – CRUD /tasks/:id', () {
+    late MockServerHandle handle;
+    late DioService dio;
+
+    setUp(() async {
+      handle = await startTasksMockServer();
+      dio = DioService(baseUrl: handle.baseUrl);
+    });
+    tearDown(() => handle.stop());
+
+    test('GET returns the seeded task by id', () async {
+      final all = await dio.getRequest('/tasks');
+      final id = (all.data as List).first['id'] as String;
+
+      final r = await dio.getRequest('/tasks/$id');
+
+      expect(r.statusCode, 200);
+      expect(r.data['id'], id);
+    });
+
+    test('POST creates a task and GET confirms the persisted record', () async {
+      final created = await dio.postRequest(
+        '/tasks',
+        data: {
+          'title': 'Integration Task',
+          'description': 'Created by DioService integration test',
+          'isCompleted': false,
+          'priority': 'LOW',
+          'ownerId': 'owner-test-001',
+        },
+      );
+
+      expect(created.statusCode, 201);
+      final id = created.data['id'] as String;
+      expect(id.isNotEmpty, isTrue);
+      expect(created.data['title'], 'Integration Task');
+
+      final fetched = await dio.getRequest('/tasks/$id');
+      expect(fetched.statusCode, 200);
+      expect(fetched.data['title'], 'Integration Task');
+      expect(fetched.data['priority'], 'LOW');
+    });
+
+    test('PUT updates the target record in-place', () async {
+      final all = await dio.getRequest('/tasks');
+      final id = (all.data as List).first['id'] as String;
+
+      final updated = await dio.putRequest(
+        '/tasks/$id',
+        data: {'title': 'Updated via PUT', 'isCompleted': true},
+      );
+
+      expect(updated.statusCode, 200);
+      expect(updated.data['title'], 'Updated via PUT');
+      expect(updated.data['isCompleted'], isTrue);
+
+      // Confirm the change is persisted.
+      final refetched = await dio.getRequest('/tasks/$id');
+      expect(refetched.data['title'], 'Updated via PUT');
+    });
+
+    test('DELETE removes the record and returns deleted:true', () async {
+      // Create a fresh task so we do not disturb seeded records used by
+      // other tests in this group.
+      final created = await dio.postRequest(
+        '/tasks',
+        data: {
+          'title': 'To Be Deleted',
+          'description': 'Ephemeral',
+          'isCompleted': false,
+          'priority': 'LOW',
+          'ownerId': 'owner-test-002',
+        },
+      );
+      final id = created.data['id'] as String;
+
+      final deleted = await dio.deleteRequest('/tasks/$id');
+
+      expect(deleted.statusCode, 200);
+      expect(deleted.data['deleted'], isTrue);
+    });
+
+    test(
+      'GET non-existent task throws Exception (404 → DioException wrapped)',
+      () async {
+        expect(
+          () => dio.getRequest('/tasks/this-id-does-not-exist'),
+          throwsA(isA<Exception>()),
+        );
+      },
+    );
+  });
+
+  group('DioService – /task-groups CRUD', () {
+    late MockServerHandle handle;
+    late DioService dio;
+
+    setUp(() async {
+      handle = await startTasksMockServer();
+      dio = DioService(baseUrl: handle.baseUrl);
+    });
+    tearDown(() => handle.stop());
+
+    test('GET returns all 5 seeded groups', () async {
+      final r = await dio.getRequest('/task-groups');
+
+      expect(r.statusCode, 200);
+      expect((r.data as List).length, 5);
+    });
+
+    test('filters groups by isActive', () async {
+      final r = await dio.getRequest(
+        '/task-groups',
+        queryParameters: {'isActive': 'true'},
+      );
+      final groups = r.data as List;
+
+      expect(
+        groups.every((g) => (g as Map<String, dynamic>)['isActive'] == true),
+        isTrue,
+      );
+    });
+
+    test('POST creates a group with generated id', () async {
+      final r = await dio.postRequest(
+        '/task-groups',
+        data: {
+          'name': 'Work',
+          'description': 'All work-related tasks',
+          'ownerId': 'owner-test-003',
+          'isActive': true,
+        },
+      );
+
+      expect(r.statusCode, 201);
+      expect(r.data['name'], 'Work');
+      expect((r.data['id'] as String).isNotEmpty, isTrue);
+    });
+
+    test('PUT updates a group field', () async {
+      final all = await dio.getRequest('/task-groups');
+      final id = (all.data as List).first['id'] as String;
+
+      final updated = await dio.putRequest(
+        '/task-groups/$id',
+        data: {'name': 'Renamed Group', 'isActive': false},
+      );
+
+      expect(updated.statusCode, 200);
+      expect(updated.data['name'], 'Renamed Group');
+      expect(updated.data['isActive'], isFalse);
+    });
+
+    test('DELETE removes the group', () async {
+      final created = await dio.postRequest(
+        '/task-groups',
+        data: {
+          'name': 'Temp Group',
+          'description': 'Will be deleted',
+          'ownerId': 'owner-test-004',
+          'isActive': true,
+        },
+      );
+      final id = created.data['id'] as String;
+
+      final deleted = await dio.deleteRequest('/task-groups/$id');
+
+      expect(deleted.statusCode, 200);
+      expect(deleted.data['deleted'], isTrue);
+    });
+  });
+
+  group('DioService – error injection (rate: 1.0)', () {
+    late MockServerHandle handle;
+    late DioService dio;
+
+    setUp(() async {
+      handle = await startTasksMockServer();
+      dio = DioService(baseUrl: handle.baseUrl);
+    });
+    tearDown(() => handle.stop());
+
+    test('/test/always-error always returns 503 '
+        'and DioService wraps it as Exception', () async {
+      await expectLater(
+        dio.getRequest('/test/always-error'),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('DioService – response delay (delay_ms)', () {
+    late MockServerHandle handle;
+    late DioService dio;
+
+    setUp(() async {
+      handle = await startTasksMockServer();
+      dio = DioService(baseUrl: handle.baseUrl);
+    });
+    tearDown(() => handle.stop());
+
+    test(
+      '/test/delayed returns correct body after the configured delay',
+      () async {
+        final watch = Stopwatch()..start();
+        final r = await dio.getRequest('/test/delayed');
+        watch.stop();
+
+        expect(r.statusCode, 200);
+        expect(r.data['ok'], isTrue);
+        // The mock is configured with delay_ms: 50.  Verify at least some delay
+        // was applied; use a generous lower bound to avoid flakiness on CI.
+        expect(watch.elapsedMilliseconds, greaterThanOrEqualTo(40));
+      },
+    );
+  });
+}

--- a/test/integration/task_datasource_integration_test.dart
+++ b/test/integration/task_datasource_integration_test.dart
@@ -1,0 +1,172 @@
+// Integration tests for TaskDatasource against a live FlutterMockServer.
+//
+// Unlike the unit tests in task_datasource_test.dart (which mock DioService),
+// these tests use a *real* DioService wired to a real local HTTP server so the
+// full serialisation / deserialisation path is exercised end-to-end:
+//
+//   TaskDatasource → DioService → Dio HTTP client → FlutterMockServer
+//                                                ↓
+//     TaskEntity  ← TaskModel.fromMap ← JSON body ←─────────────────────────
+import 'package:flutter_test/flutter_test.dart';
+import 'package:organize_it/features/tasks/data/datasources/task_datasource.dart';
+import 'package:organize_it/features/tasks/domain/entities/task.dart';
+import 'package:organize_it/services/dio_service.dart';
+
+import '../helpers/mock_server_helper.dart';
+
+void main() {
+  group('TaskDatasource integration', () {
+    late MockServerHandle handle;
+    late TaskDatasource datasource;
+
+    setUp(() async {
+      handle = await startTasksMockServer();
+      datasource = TaskDatasource(
+        dioService: DioService(baseUrl: handle.baseUrl),
+      );
+    });
+    tearDown(() => handle.stop());
+
+    // ── getTasks ─────────────────────────────────────────────────────────────
+
+    test(
+      'getTasks() maps all 12 seeded records into TaskEntity instances',
+      () async {
+        final tasks = await datasource.getTasks();
+
+        expect(tasks, isA<List<TaskEntity>>());
+        expect(tasks.length, 12);
+        // Verify that every record round-trips through TaskModel correctly.
+        for (final task in tasks) {
+          expect(task.id.isNotEmpty, isTrue);
+          expect(task.title.isNotEmpty, isTrue);
+          expect(TaskPriority.values.contains(task.priority), isTrue);
+        }
+      },
+    );
+
+    // ── getTasksByDate ────────────────────────────────────────────────────────
+
+    test('getTasksByDate() returns an empty list when no record has a '
+        'matching "date" field', () async {
+      // The Task model has no "date" field. The mock server filters
+      // ?date=X by strict equality, so all records are excluded.
+      final tasks = await datasource.getTasksByDate('2025-01-01');
+
+      expect(tasks, isA<List<TaskEntity>>());
+      expect(tasks, isEmpty);
+    });
+
+    // ── getTaskById ───────────────────────────────────────────────────────────
+
+    test('getTaskById() returns the matching entity', () async {
+      final all = await datasource.getTasks();
+      final expected = all.first;
+
+      final found = await datasource.getTaskById(expected.id);
+
+      expect(found.id, expected.id);
+      expect(found.title, expected.title);
+      expect(found.priority, expected.priority);
+      expect(found.ownerId, expected.ownerId);
+    });
+
+    test('getTaskById() throws Exception for an unknown id', () async {
+      await expectLater(
+        datasource.getTaskById('id-that-does-not-exist'),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    // ── addTask ───────────────────────────────────────────────────────────────
+
+    test('addTask() persists the task so the store grows by one', () async {
+      const newTask = TaskEntity(
+        id: '',
+        title: 'My Integration Task',
+        description: 'Added through the real mock server',
+        isCompleted: false,
+        priority: TaskPriority.high,
+        ownerId: 'owner-integration-001',
+      );
+
+      await expectLater(datasource.addTask(newTask), completes);
+
+      final all = await datasource.getTasks();
+      expect(all.length, 13);
+      expect(all.any((t) => t.title == 'My Integration Task'), isTrue);
+    });
+
+    test('addTask() round-trips priority correctly', () async {
+      for (final priority in TaskPriority.values) {
+        final task = TaskEntity(
+          id: '',
+          title: 'Priority test ${priority.serverName}',
+          description: 'Testing priority ${priority.serverName}',
+          isCompleted: false,
+          priority: priority,
+          ownerId: 'owner-priority-test',
+        );
+
+        // Should not throw regardless of priority value.
+        await expectLater(datasource.addTask(task), completes);
+      }
+    });
+
+    // ── updateTask ────────────────────────────────────────────────────────────
+
+    test('updateTask() modifies the target record in the store', () async {
+      final all = await datasource.getTasks();
+      final target = all.first;
+
+      await datasource.updateTask(target.id, {
+        'title': 'Renamed via updateTask',
+        'isCompleted': true,
+      });
+
+      final refreshed = await datasource.getTaskById(target.id);
+      expect(refreshed.title, 'Renamed via updateTask');
+      expect(refreshed.isCompleted, isTrue);
+    });
+
+    test('updateTask() merges id into the payload (no id collision)', () async {
+      final all = await datasource.getTasks();
+      final target = all.last;
+
+      // The datasource adds `id` to the payload internally; the mock server
+      // must not end up with a duplicate-id conflict.
+      await expectLater(
+        datasource.updateTask(target.id, {'description': 'Updated desc'}),
+        completes,
+      );
+
+      final refreshed = await datasource.getTaskById(target.id);
+      expect(refreshed.description, 'Updated desc');
+    });
+
+    // ── deleteTask ────────────────────────────────────────────────────────────
+
+    test(
+      'deleteTask() removes the record so a subsequent GET throws',
+      () async {
+        final all = await datasource.getTasks();
+        final target = all.last;
+
+        await datasource.deleteTask(target.id);
+
+        await expectLater(
+          datasource.getTaskById(target.id),
+          throwsA(isA<Exception>()),
+        );
+      },
+    );
+
+    test('deleteTask() reduces the store count by one', () async {
+      final before = await datasource.getTasks();
+      await datasource.deleteTask(before.last.id);
+      final after = await datasource.getTasks();
+
+      expect(after.length, before.length - 1);
+    });
+  });
+}


### PR DESCRIPTION
- Add flutter_mock_server to dev_dependencies
- Add mock.yaml with CRUD routes for tasks and task-groups, auth, health, error injection, and delay simulation
- Add .vscode/tasks.json to auto-start mock server as a pre-launch task
- Add .vscode/launch.json configs for Chrome + mock server (CORS bypass)
- Add test/helpers/mock_server_helper.dart shared test utility
- Add test/integration/ with 31 passing integration tests covering DioService and TaskDatasource against a live mock server